### PR TITLE
ci: only run vercel deployments when changelog have not changed

### DIFF
--- a/.github/workflows/deploy-website-production.yaml
+++ b/.github/workflows/deploy-website-production.yaml
@@ -5,10 +5,11 @@ on:
   push:
     branches:
       - main
-      # TODO: uncomment the following line when prod deployment is confirmed
-    # paths:
-    #   - website/**/*
-    #   - .github/workflows/deploy-website-production.yaml      
+    paths:
+      - website/**/*
+      - .github/workflows/deploy-website-production.yaml  
+    paths-ignore:
+      - 'CHANGELOG.md'          
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,8 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
+    paths-ignore:
+      - 'CHANGELOG.md'
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
## Description
### What this PR does
Only run Vercel deployments when `CHANGELOG.md` is not changed

